### PR TITLE
feat: refine homepage banner in dark mode

### DIFF
--- a/src/pages/home/css/index.module.css
+++ b/src/pages/home/css/index.module.css
@@ -55,3 +55,23 @@
 .getStartedButton {
   color: white !important;
 }
+
+[data-theme="dark"] .heroBanner {
+  background: linear-gradient(45deg, #232526, #414345);
+}
+
+[data-theme="dark"] .button--secondary {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: white;
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+[data-theme="dark"] .button--secondary:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+  border-color: white;
+}
+
+[data-theme="dark"] .title,
+[data-theme="dark"] .subtitle {
+  color: white;
+}


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/c7cc904c-87de-4c84-9728-5d90c88233f9)

after:
![image](https://github.com/user-attachments/assets/dbb3e46d-5534-4ee9-a53c-c182af412770)

