### PR TITLE
fix(docs): corrected the typo in docs/versioned

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.11/specification/xlang_serialization_spec.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.11/specification/xlang_serialization_spec.md
@@ -73,7 +73,7 @@ also introduce more complexities compared to static serialization frameworks. So
 - binary: an variable-length array of bytes.
 - array: only allow 1d numeric components. Other arrays will be taken as List. The implementation should support the
   interoperability between array and list.
-  - bool_array: one dimensional int16 array.
+  - bool_array: one dimensional bool array.
   - int8_array: one dimensional int8 array.
   - int16_array: one dimensional int16 array.
   - int32_array: one dimensional int32 array.

--- a/versioned_docs/version-0.10/specification/xlang_serialization_spec.md
+++ b/versioned_docs/version-0.10/specification/xlang_serialization_spec.md
@@ -73,7 +73,7 @@ also introduce more complexities compared to static serialization frameworks. So
 - binary: an variable-length array of bytes.
 - array: only allow 1d numeric components. Other arrays will be taken as List. The implementation should support the
   interoperability between array and list.
-  - bool_array: one dimensional int16 array.
+  - bool_array: one dimensional bool array.
   - int8_array: one dimensional int8 array.
   - int16_array: one dimensional int16 array.
   - int32_array: one dimensional int32 array.

--- a/versioned_docs/version-0.11/specification/xlang_serialization_spec.md
+++ b/versioned_docs/version-0.11/specification/xlang_serialization_spec.md
@@ -73,7 +73,7 @@ also introduce more complexities compared to static serialization frameworks. So
 - binary: an variable-length array of bytes.
 - array: only allow 1d numeric components. Other arrays will be taken as List. The implementation should support the
   interoperability between array and list.
-  - bool_array: one dimensional int16 array.
+  - bool_array: one dimensional bool array.
   - int8_array: one dimensional int8 array.
   - int16_array: one dimensional int16 array.
   - int32_array: one dimensional int32 array.

--- a/versioned_docs/version-0.12/specification/xlang_serialization_spec.md
+++ b/versioned_docs/version-0.12/specification/xlang_serialization_spec.md
@@ -73,7 +73,7 @@ also introduce more complexities compared to static serialization frameworks. So
 - binary: an variable-length array of bytes.
 - array: only allow 1d numeric components. Other arrays will be taken as List. The implementation should support the
   interoperability between array and list.
-  - bool_array: one dimensional int16 array.
+  - bool_array: one dimensional bool array.
   - int8_array: one dimensional int8 array.
   - int16_array: one dimensional int16 array.
   - int32_array: one dimensional int32 array.

--- a/versioned_docs/version-0.13/specification/xlang_serialization_spec.md
+++ b/versioned_docs/version-0.13/specification/xlang_serialization_spec.md
@@ -73,7 +73,7 @@ also introduce more complexities compared to static serialization frameworks. So
 - binary: an variable-length array of bytes.
 - array: only allow 1d numeric components. Other arrays will be taken as List. The implementation should support the
   interoperability between array and list.
-  - bool_array: one dimensional int16 array.
+  - bool_array: one dimensional bool array.
   - int8_array: one dimensional int8 array.
   - int16_array: one dimensional int16 array.
   - int32_array: one dimensional int32 array.

--- a/versioned_docs/version-0.14/specification/xlang_serialization_spec.md
+++ b/versioned_docs/version-0.14/specification/xlang_serialization_spec.md
@@ -69,7 +69,7 @@ This specification defines the Fory xlang binary format. The format is dynamic r
 - binary: an variable-length array of bytes.
 - array: only allow 1d numeric components. Other arrays will be taken as List. The implementation should support the
   interoperability between array and list.
-  - bool_array: one dimensional int16 array.
+  - bool_array: one dimensional bool array.
   - int8_array: one dimensional int8 array.
   - int16_array: one dimensional int16 array.
   - int32_array: one dimensional int32 array.


### PR DESCRIPTION
The old definition of `bool_array` had a typo,
```
  - bool_array: one dimensional int16 array.
```

Which is now corrected to 
```
  - bool_array: one dimensional bool array.
```