### PR TITLE
[DOCS] Fix sidebar_positions for basic serialization and configuration #427

### DIFF
--- a/docs/guide/dart/basic-serialization.md
+++ b/docs/guide/dart/basic-serialization.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Serialization
-sidebar_position: 2
+sidebar_position: 1
 id: dart_basic_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/docs/guide/dart/configuration.md
+++ b/docs/guide/dart/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-sidebar_position: 1
+sidebar_position: 2
 id: dart_configuration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/cpp/basic-serialization.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/cpp/basic-serialization.md
@@ -1,6 +1,6 @@
 ---
 title: 基础序列化
-sidebar_position: 2
+sidebar_position: 1
 id: basic_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/cpp/configuration.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/cpp/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: 配置
-sidebar_position: 1
+sidebar_position: 2
 id: configuration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/dart/basic-serialization.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/dart/basic-serialization.md
@@ -1,6 +1,6 @@
 ---
 title: 基础序列化
-sidebar_position: 2
+sidebar_position: 1
 id: dart_basic_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/dart/configuration.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/dart/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: 配置
-sidebar_position: 1
+sidebar_position: 2
 id: dart_configuration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/go/basic-serialization.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/go/basic-serialization.md
@@ -1,6 +1,6 @@
 ---
 title: 基本序列化
-sidebar_position: 20
+sidebar_position: 10
 id: basic_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/go/configuration.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/go/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: 配置
-sidebar_position: 10
+sidebar_position: 20
 id: configuration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/java/basic-serialization.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/java/basic-serialization.md
@@ -1,6 +1,6 @@
 ---
 title: 基础序列化
-sidebar_position: 2
+sidebar_position: 1
 id: basic_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/java/configuration.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/java/configuration.md
@@ -1,6 +1,6 @@
 ---
-title: 配置选项
-sidebar_position: 1
+title: 配置
+sidebar_position: 2
 id: configuration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/python/basic-serialization.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/python/basic-serialization.md
@@ -1,6 +1,6 @@
 ---
 title: 基础序列化
-sidebar_position: 2
+sidebar_position: 1
 id: basic_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/python/configuration.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/python/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: 配置
-sidebar_position: 1
+sidebar_position: 2
 id: configuration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/rust/basic-serialization.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/rust/basic-serialization.md
@@ -1,6 +1,6 @@
 ---
 title: 基础序列化
-sidebar_position: 2
+sidebar_position: 1
 id: basic_serialization
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/rust/configuration.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/guide/rust/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: 配置
-sidebar_position: 1
+sidebar_position: 2
 id: configuration
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "aos": "^2.3.4",
         "clsx": "^2.0.0",
         "docusaurus-lunr-search": "^3.3.1",
+        "framer-motion": "^12.18.1",
         "prism-react-renderer": "^2.3.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -35,7 +36,7 @@
         "yaml": "^2.8.0"
       },
       "engines": {
-        "node": ">=18.0"
+        "node": ">=24.0"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -8894,6 +8895,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -13062,6 +13090,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/mrmime": {
       "version": "2.0.0",


### PR DESCRIPTION
### Description:

**Summary**
This PR corrects the sidebar order in the docs/ and i18n/ directories. Specifically, it ensures that "Basic Serialization" is positioned before "Configuration" to maintain consistency with the core documentation.

**Changes**

- Swapped sidebar_position values for basic_serialization.md and configuration.md in all language guides (Java, Python, C++, etc.).
- Fixed the missing sidebar_position update in the Dart language section which was previously overlooked.
- Applied the same changes to the i18n/zh-CN/ directory to ensure localized docs are in sync.
- update package-lock to match node 24 requirements.

**Verification**

- Verified the sidebar order via npm run start-zh and npm run start-en.
- Passed npm run typecheck.

Fixes #427
Related to apache/fory#3447