### PR TITLE
chore: remove unused i18n keys

### DIFF
--- a/i18n/en-US/code.json
+++ b/i18n/en-US/code.json
@@ -274,30 +274,6 @@
     "message": "This page is unlisted. Search engines will not index it, and only users having a direct link can access it.",
     "description": "The unlisted content banner message"
   },
-  "feature.highPerformance.title": {
-    "message": "High performance",
-    "description": "The title for the high performance feature"
-  },
-  "feature.highPerformance.description": {
-    "message": "Compared to other serialization frameworks, there is a 20~170x speed up.",
-    "description": "Description for the high performance feature"
-  },
-  "feature.easyToUse.title": {
-    "message": "Easy to use",
-    "description": "The title for the easy to use feature"
-  },
-  "feature.easyToUse.description": {
-    "message": "No need for DSL, you can use Apache Fory™ effectively with your intuition.",
-    "description": "Description for the easy to use feature"
-  },
-  "feature.multiLanguages.title": {
-    "message": "Multi-languages",
-    "description": "The title for the multi-languages feature"
-  },
-  "feature.multiLanguages.description": {
-    "message": "Supports popular programming languages such as Java, Python, C++, Golang, Javascript, Rust, and more will be added in the future.",
-    "description": "Description for the multi-languages feature"
-  },
   "homepage.githubButton": {
     "message": "GitHub",
     "description": "The GitHub button label on the homepage"

--- a/i18n/en-us/docusaurus-plugin-content-docs/current.json
+++ b/i18n/en-us/docusaurus-plugin-content-docs/current.json
@@ -6,13 +6,5 @@
   "sidebar.docsSidebar.category.Introduction": {
     "message": "Introduction",
     "description": "The label for category Introduction in sidebar docsSidebar"
-  },
-  "sidebar.docsSidebar.category.Start": {
-    "message": "Start",
-    "description": "The label for category Start in sidebar docsSidebar"
-  },
-  "sidebar.docsSidebar.category.Guide": {
-    "message": "Guide",
-    "description": "The label for category Guide in sidebar docsSidebar"
   }
 }

--- a/i18n/en-us/docusaurus-theme-classic/navbar.json
+++ b/i18n/en-us/docusaurus-theme-classic/navbar.json
@@ -3,18 +3,6 @@
     "message": "Apache Fory™ Logo",
     "description": "The alt text of navbar logo"
   },
-  "item.label.Start": {
-    "message": "Start",
-    "description": "Navbar item with label Start"
-  },
-  "item.label.Introduction": {
-    "message": "Introduction",
-    "description": "Navbar item with label Introduction"
-  },
-  "item.label.Guide": {
-    "message": "Guide",
-    "description": "Navbar item with label Guide"
-  },
   "item.label.Specification": {
     "message": "Specification",
     "description": "Navbar item with label Specification"

--- a/i18n/zh-CN/docusaurus-theme-classic/navbar.json
+++ b/i18n/zh-CN/docusaurus-theme-classic/navbar.json
@@ -7,18 +7,6 @@
     "message": "文档",
     "description": "Navbar item with label Docs"
   },
-  "item.label.Start": {
-    "message": "快速开始",
-    "description": "Navbar item with label Start"
-  },
-  "item.label.Introduction": {
-    "message": "Apache Fory 介绍",
-    "description": "Navbar item with label Introduction"
-  },
-  "item.label.Guide": {
-    "message": "用户指南",
-    "description": "Navbar item with label Guide"
-  },
   "item.label.Specification": {
     "message": "规范",
     "description": "Navbar item with label Specification"


### PR DESCRIPTION
  ## Summary
  - Remove 6 unused feature keys from `en-US/code.json` (`feature.highPerformance.*`, `feature.easyToUse.*`, `feature.multiLanguages.*`) — no references in source code
  - Remove `sidebar.docsSidebar.category.Start` and `Guide` from `en-US/current.json` — current sidebar uses `Getting Started` instead
  - Remove `item.label.Start`, `Introduction`, `Guide` from both `en-US` and `zh-CN` `navbar.json` — not present in navbar config

  ## Verification
  - Cross-referenced all deleted keys against `sidebars.ts`, `docusaurus.config.ts` navbar config, and `src/pages/home/components/` source files
  - Versioned i18n files (`version-*.json`) were intentionally not modified — their keys match their respective versioned sidebar structures